### PR TITLE
Fix strings and apply centerHorizonal in force mapping info dialog buttons

### DIFF
--- a/app/src/main/java/com/toast/android/gamebase/sample/ui/settings/idpmap/IdpMappingScreen.kt
+++ b/app/src/main/java/com/toast/android/gamebase/sample/ui/settings/idpmap/IdpMappingScreen.kt
@@ -159,12 +159,12 @@ private fun ForceMappingInfoDialog(
                     TextButton(
                         onClick = onForceMapping
                     ) {
-                        Text(stringResource(id = R.string.idp_mapping_guide_force_mapping, mappedUserId))
+                        Text(stringResource(id = R.string.idp_mapping_guide_force_mapping))
                     }
                     TextButton(
                         onClick = onChangeLogin
                     ) {
-                        Text(stringResource(id = R.string.idp_mapping_guide_change_login, mappedUserId))
+                        Text(stringResource(id = R.string.idp_mapping_guide_change_login))
                     }
                     TextButton(
                         onClick = onCancel

--- a/app/src/main/java/com/toast/android/gamebase/sample/ui/settings/idpmap/IdpMappingScreen.kt
+++ b/app/src/main/java/com/toast/android/gamebase/sample/ui/settings/idpmap/IdpMappingScreen.kt
@@ -34,6 +34,7 @@ import androidx.compose.ui.res.dimensionResource
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.window.Dialog
 import androidx.lifecycle.viewmodel.compose.viewModel
 import com.toast.android.gamebase.base.GamebaseException
@@ -152,7 +153,8 @@ private fun ForceMappingInfoDialog(
                     textAlign = TextAlign.Left
                 )
                 Column(
-                    modifier = Modifier.fillMaxWidth()
+                    modifier = Modifier.fillMaxWidth(),
+                    horizontalAlignment = Alignment.CenterHorizontally
                 ) {
                     TextButton(
                         onClick = onForceMapping
@@ -304,4 +306,10 @@ fun ListItem(
             }
         }
     }
+}
+
+@Preview
+@Composable
+fun PreviewForceMappingInfoDialog() {
+    ForceMappingInfoDialog("Google", "sampleId", {}, {}, {})
 }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -101,8 +101,8 @@
     <string name="idp_mapping_force_mapping_failed_dialog_description">계정 강제 연동에 실패하였습니다.</string>
     <string name="idp_mapping_change_login_failed_dialog_description">로그인 계정 변경에 실패하였습니다.</string>
     <string name="idp_mapping_already_mapped">선택한 %1$s에 매핑된 계정이 이미 존재합니다.(%2$s) </string>
-    <string name="idp_mapping_guide_force_mapping">%s계정을 삭제하고 현재 로그인 된 계정으로 강제 연동 하기</string>
-    <string name="idp_mapping_guide_change_login">현재 로그인 된 계정에서 로그아웃 하고 %s로 로그인 하기</string>
+    <string name="idp_mapping_guide_force_mapping">기존 계정을 삭제하고 현재 로그인된 계정으로 강제 연동 하기</string>
+    <string name="idp_mapping_guide_change_login">현재 로그인된 계정에서 로그아웃 하고 기존 계정 로그인 하기</string>
 
     <!-- developer menu string array -->
     <!-- never translate this -->

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -101,8 +101,8 @@
     <string name="idp_mapping_force_mapping_failed_dialog_description">계정 강제 연동에 실패하였습니다.</string>
     <string name="idp_mapping_change_login_failed_dialog_description">로그인 계정 변경에 실패하였습니다.</string>
     <string name="idp_mapping_already_mapped">선택한 %1$s에 매핑된 계정이 이미 존재합니다.(%2$s) </string>
-    <string name="idp_mapping_guide_force_mapping">%s 계정을 삭제하고 현재 로그인 된 계정으로 강제 연동 하시겠습니까?</string>
-    <string name="idp_mapping_guide_change_login">현재 로그인 된 계정에서 로그아웃 하고 %s로 로그인 하시겠습니까?</string>
+    <string name="idp_mapping_guide_force_mapping">%s계정을 삭제하고 현재 로그인 된 계정으로 강제 연동 하기</string>
+    <string name="idp_mapping_guide_change_login">현재 로그인 된 계정에서 로그아웃 하고 %s로 로그인 하기</string>
 
     <!-- developer menu string array -->
     <!-- never translate this -->


### PR DESCRIPTION
* 강제매핑 다이얼로그 문구 수정 
* 버튼에 중앙정렬 적용
![image](https://user-images.githubusercontent.com/111415015/224237349-3ff1503f-c209-4bec-b878-605eb7f26d5f.png)
