### PR TITLE
Go back to Splash when Gamebase is not initialized

### DIFF
--- a/app/src/main/java/com/toast/android/gamebase/sample/GamebaseApplication.kt
+++ b/app/src/main/java/com/toast/android/gamebase/sample/GamebaseApplication.kt
@@ -5,13 +5,14 @@ import com.toast.android.gamebase.sample.gamebase_manager.getAppKey
 import com.toast.android.gamebase.sample.gamebase_manager.initializeNhnCloudLogger
 import com.toast.android.gamebase.sample.gamebase_manager.setNhnCloudLoggerListener
 
-const val TAG = "GamebaseApplication"
-
 class GamebaseApplication : MultiDexApplication() {
     companion object {
         lateinit var instance: GamebaseApplication
             private set
     }
+
+    // Application의 재생성을 탐지하기 위해 Application이 생성될 때 launchedTime 저장
+    val launchedTime = System.currentTimeMillis()
 
     override fun onCreate() {
         super.onCreate()

--- a/app/src/main/java/com/toast/android/gamebase/sample/ui/MainActivity.kt
+++ b/app/src/main/java/com/toast/android/gamebase/sample/ui/MainActivity.kt
@@ -9,6 +9,7 @@ import androidx.compose.runtime.setValue
 import com.toast.android.gamebase.Gamebase
 import com.toast.android.gamebase.sample.BuildConfig
 import com.toast.android.gamebase.sample.GamebaseActivity
+import com.toast.android.gamebase.sample.GamebaseApplication
 import com.toast.android.gamebase.sample.ui.access_info.AccessInformationScreen
 import com.toast.android.gamebase.sample.ui.navigation.SampleAppScreens
 import com.toast.android.gamebase.sample.ui.theme.GamebaseSampleProjectTheme
@@ -18,13 +19,20 @@ import com.toast.android.gamebase.sample.util.putIntInPreference
 class MainActivity : GamebaseActivity() {
     companion object {
         const val KEY_LAST_ACCESS_INFO_SHOWN_VERSION = "gamebase.sample.pref.access.info.shown.version"
+        private const val APPLICATION_LAUNCHED_TIME = "applicationLaunchedTime"
     }
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
 
-        val startRoute =
-            if (Gamebase.isInitialized()) SampleAppScreens.Login.route else SampleAppScreens.Splash.route
+        // Gamebase가 초기화 되었으면 Splash를 스킵하고 Login 화면부터 띄워준다.
+        var startRoute = if (Gamebase.isInitialized()) SampleAppScreens.Login.route else SampleAppScreens.Splash.route
+
+        // 그런데 앱이 재시작된 상태면 splash를 띄워 다시 초기화를 한다.
+        if (isProcessRestarted(savedInstanceState)) {
+            startRoute = SampleAppScreens.Splash.route
+        }
+
         var shouldShowAccessInformationScreen by mutableStateOf(true)
 
         if (getIntInPreference(applicationContext, KEY_LAST_ACCESS_INFO_SHOWN_VERSION, -1) == BuildConfig.VERSION_CODE) {
@@ -42,6 +50,16 @@ class MainActivity : GamebaseActivity() {
                 }
             }
         }
+    }
+
+    override fun onSaveInstanceState(outState: Bundle) {
+        super.onSaveInstanceState(outState)
+        outState.putLong(APPLICATION_LAUNCHED_TIME, (application as GamebaseApplication).launchedTime)
+    }
+
+    private fun isProcessRestarted(savedInstanceState: Bundle?): Boolean {
+        val savedApplicationLaunchedTime = savedInstanceState?.getLong(APPLICATION_LAUNCHED_TIME)
+        return (application as GamebaseApplication).launchedTime != savedApplicationLaunchedTime
     }
 }
 

--- a/app/src/main/java/com/toast/android/gamebase/sample/ui/MainActivity.kt
+++ b/app/src/main/java/com/toast/android/gamebase/sample/ui/MainActivity.kt
@@ -26,12 +26,7 @@ class MainActivity : GamebaseActivity() {
         super.onCreate(savedInstanceState)
 
         // Gamebase가 초기화 되었으면 Splash를 스킵하고 Login 화면부터 띄워준다.
-        var startRoute = if (Gamebase.isInitialized()) SampleAppScreens.Login.route else SampleAppScreens.Splash.route
-
-        // 그런데 앱이 재시작된 상태면 splash를 띄워 다시 초기화를 한다.
-        if (isProcessRestarted(savedInstanceState)) {
-            startRoute = SampleAppScreens.Splash.route
-        }
+        val startRoute = if (Gamebase.isInitialized()) SampleAppScreens.Login.route else SampleAppScreens.Splash.route
 
         var shouldShowAccessInformationScreen by mutableStateOf(true)
 
@@ -43,7 +38,8 @@ class MainActivity : GamebaseActivity() {
                 LoadStartScreen(
                     activity = this,
                     startRoute = startRoute,
-                    shouldShowAccessInformationScreen = shouldShowAccessInformationScreen
+                    isProcessRestart = isProcessRestarted(savedInstanceState),
+                    shouldShowAccessInformationScreen = shouldShowAccessInformationScreen,
                 ) {
                     shouldShowAccessInformationScreen = false
                     putIntInPreference(applicationContext, KEY_LAST_ACCESS_INFO_SHOWN_VERSION, BuildConfig.VERSION_CODE)
@@ -68,6 +64,7 @@ fun LoadStartScreen(
     activity: GamebaseActivity,
     startRoute: String,
     shouldShowAccessInformationScreen: Boolean,
+    isProcessRestart: Boolean,
     updateVersionInPreferenceAndState: () -> Unit
 ) {
     if (shouldShowAccessInformationScreen) {
@@ -75,7 +72,8 @@ fun LoadStartScreen(
     } else {
         MainScreen(
             activity = activity,
-            startRoute = startRoute
+            startRoute = startRoute,
+            isProcessRestart = isProcessRestart
         )
     }
 }

--- a/app/src/main/java/com/toast/android/gamebase/sample/ui/MainScreen.kt
+++ b/app/src/main/java/com/toast/android/gamebase/sample/ui/MainScreen.kt
@@ -44,7 +44,8 @@ import kotlinx.coroutines.launch
 @Composable
 fun MainScreen(
     activity: GamebaseActivity,
-    startRoute: String
+    startRoute: String,
+    isProcessRestart: Boolean = false,
 ) {
     val navController = rememberNavController()
     val scaffoldState = rememberScaffoldState()
@@ -52,11 +53,12 @@ fun MainScreen(
     val networkState = remember { mutableStateOf(-1) }
 
     val currentBackStackEntry = navController.currentBackStackEntryAsState()
-    val currentScreen = SampleAppScreens.fromRoute(
-        currentBackStackEntry.value?.destination?.route
-    )
+    val currentScreen = SampleAppScreens.fromRoute(currentBackStackEntry.value?.destination?.route)
     LaunchedEffect (Unit) {
-        jumpToRoute(navController, scope, scaffoldState, startRoute)
+        if (isProcessRestart) {
+            jumpToRoute(navController, scope, scaffoldState, SampleAppScreens.Splash.route)
+        }
+
         fun getNetworkStateMessage(
             context: Context,
             code: Int

--- a/app/src/main/java/com/toast/android/gamebase/sample/ui/MainScreen.kt
+++ b/app/src/main/java/com/toast/android/gamebase/sample/ui/MainScreen.kt
@@ -30,6 +30,7 @@ import androidx.navigation.NavGraph.Companion.findStartDestination
 import androidx.navigation.NavHostController
 import androidx.navigation.compose.currentBackStackEntryAsState
 import androidx.navigation.compose.rememberNavController
+import com.toast.android.gamebase.Gamebase
 import com.toast.android.gamebase.base.NetworkManager
 import com.toast.android.gamebase.sample.GamebaseActivity
 import com.toast.android.gamebase.sample.R
@@ -56,6 +57,10 @@ fun MainScreen(
         currentBackStackEntry.value?.destination?.route
     )
     LaunchedEffect (Unit) {
+        if (!Gamebase.isInitialized()) {
+            // 게임베이스가 초기화되어있지 않다면 splash스크린으로 돌아가 다시 초기화를 수행한다.
+            onDestinationClicked(navController, scope, scaffoldState, SampleAppScreens.Splash.route)
+        }
         fun getNetworkStateMessage(
             context: Context,
             code: Int

--- a/app/src/main/java/com/toast/android/gamebase/sample/ui/MainScreen.kt
+++ b/app/src/main/java/com/toast/android/gamebase/sample/ui/MainScreen.kt
@@ -30,7 +30,6 @@ import androidx.navigation.NavGraph.Companion.findStartDestination
 import androidx.navigation.NavHostController
 import androidx.navigation.compose.currentBackStackEntryAsState
 import androidx.navigation.compose.rememberNavController
-import com.toast.android.gamebase.Gamebase
 import com.toast.android.gamebase.base.NetworkManager
 import com.toast.android.gamebase.sample.GamebaseActivity
 import com.toast.android.gamebase.sample.R
@@ -57,10 +56,7 @@ fun MainScreen(
         currentBackStackEntry.value?.destination?.route
     )
     LaunchedEffect (Unit) {
-        if (!Gamebase.isInitialized()) {
-            // 게임베이스가 초기화되어있지 않다면 splash스크린으로 돌아가 다시 초기화를 수행한다.
-            onDestinationClicked(navController, scope, scaffoldState, SampleAppScreens.Splash.route)
-        }
+        jumpToRoute(navController, scope, scaffoldState, startRoute)
         fun getNetworkStateMessage(
             context: Context,
             code: Int
@@ -122,7 +118,7 @@ fun MainScreen(
                 },
                 drawerContent = {
                     MainDrawer { route ->
-                        onDestinationClicked(navController, scope, scaffoldState, route)
+                        jumpToRoute(navController, scope, scaffoldState, route)
                     }
                 }
             ) { innerPadding ->
@@ -153,7 +149,7 @@ private fun getNetworkStateSnackbarColor(
         Green
     }
 
-private fun onDestinationClicked(
+private fun jumpToRoute(
     navController: NavHostController,
     scope: CoroutineScope,
     scaffoldState: ScaffoldState,


### PR DESCRIPTION
## 이슈
권한 제거로 인한 process kill 상황에서 Activity는 복원되나 Gamebase가 초기화되어있지 않아 이후의 API호출시 실패

## 수정
MainScreen에서 Gamebase 초기화상태를 체크하여 초기화되어있지 않다면 Splash로 다시 보내 Gamebase초기화 및 로그인을 수행